### PR TITLE
contrib: Fix xfce4-panel registration

### DIFF
--- a/contrib/xfce4-panel/jgmenu-applet.c
+++ b/contrib/xfce4-panel/jgmenu-applet.c
@@ -5,7 +5,7 @@
 */
 
 #include <libxfce4util/libxfce4util.h>
-#include <libxfce4panel/xfce-panel-plugin.h>
+#include <libxfce4panel/libxfce4panel.h>
 
 #define DEFAULT_ICON_NAME "jgmenu"
 #define DEFAULT_TOOLTIP_MESSAGE "Applications Menu"


### PR DESCRIPTION
Presumably due to header file reorganization,

    XFCE_PANEL_PLUGIN_REGISTER(jgmenu_construct);

did not have any effect anymore because the macro is not defined in <libxfce4panel/xfce-panel-plugin.h> anymore.  Current GCC version parse this line as a declaration of a function called XFCE_PANEL_PLUGIN_REGISTER with an implicit int return type and without a parameter list/prototype, which is the reason why this did not result in a compilation error.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
