### PR TITLE
jgmenu-apps: handle (generic) name containing commas

### DIFF
--- a/src/jgmenu-apps.c
+++ b/src/jgmenu-apps.c
@@ -63,7 +63,9 @@ static void print_app_to_buffer(struct app *app, struct sbuf *buf)
 	sbuf_cpy(&s, name);
 	fmt_name(&s, name, generic_name);
 	sbuf_replace(&s, "&", "&amp;");
+	sbuf_addstr(buf, "\"\"\"");
 	sbuf_addstr(buf, s.buf);
+	sbuf_addstr(buf, "\"\"\"");
 	sbuf_addstr(buf, ",");
 
 	/* command */


### PR DESCRIPTION
Enclose names/generic-names with """ so that commas are treated as part of the name rather than as separate CSV fields.

Fixes issue #192

Reported-by: @PPC-scripts