### PR TITLE
Move librsvg dependency to optional

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,7 +89,13 @@ Dependencies
 
 - jgmenu
 
-  * libx11, libxrandr, cairo, pango, librsvg, glib-2.0
+required:
+
+  * libx11, libxrandr, cairo, pango, glib-2.0
+
+optional:
+
+  * librsvg-2.0
 
 - apps
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #
 # Define ASAN=1 to enable AddressSanitizer
+# Define RSVG=1 to enable SVG icon support
 #
 # Define VERBOSE=1 for a more verbose compilation
 #
@@ -12,13 +13,13 @@ VER      = $(shell ./scripts/version-gen.sh)
 -include config.mk
 include Makefile.inc
 
-jgmenu:         CFLAGS += `pkg-config cairo pango pangocairo librsvg-2.0 --cflags`
+jgmenu:         CFLAGS += `pkg-config cairo pango pangocairo $(RSVG_LIB) --cflags` $(RSVG_FLAGS)
 jgmenu-ob:      CFLAGS += `xml2-config --cflags`
 jgmenu-obtheme: CFLAGS += `xml2-config --cflags`
 jgmenu-config:  CFLAGS += `pkg-config --cflags glib-2.0`
 jgmenu-apps:    CFLAGS += `pkg-config --cflags glib-2.0`
 
-jgmenu:         LIBS   += `pkg-config x11 xrandr cairo pango pangocairo librsvg-2.0 --libs`
+jgmenu:         LIBS   += `pkg-config x11 xrandr cairo pango pangocairo $(RSVG_LIB) --libs` $(RSVG_FLAGS)
 jgmenu:         LIBS   += -pthread -lpng
 jgmenu-ob:      LIBS   += `xml2-config --libs`
 jgmenu-obtheme: LIBS   += `xml2-config --libs`

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -28,6 +28,11 @@ CFLAGS    += $(ASAN_FLAGS)
 LDFLAGS   += $(ASAN_FLAGS) -fuse-ld=gold
 endif
 
+ifdef RSVG
+RSVG_LIB	= librsvg-2.0
+RSVG_FLAGS	= -DRSVG=1
+endif
+
 ifndef VERBOSE
 QUIET_CC   = @echo '     CC    '$@;
 QUIET_LINK = @echo '     LINK  '$@;

--- a/configure
+++ b/configure
@@ -19,6 +19,7 @@ Produce a config.mk file to be sourced by Makefile
 --all, -a                  Include all contrib/ packages above
 --dev, -d                  Same as --all, but also with ASAN and prefix=\$HOME
 --enable-asan              Enable address sanitizer (only during development)
+--disable-svg              Disable SVG icon support
 --prefix=<dir>             Install architecture-independent files in \$prefix
                            (e.g. --prefix=\$HOME')
 --libdir=<dir>             Specify libdir (\$prefix/lib by default)
@@ -52,9 +53,12 @@ check_core_dependencies () {
 	for b in "pkg-config" "xml2-config"; do
 		check_bin "$b"
 	done
-	for l in "x11" "xrandr" "cairo" "pango" "pangocairo" "librsvg-2.0" "glib-2.0"; do
+	for l in "x11" "xrandr" "cairo" "pango" "pangocairo" "glib-2.0"; do
 		check_lib "$l"
 	done
+	if [ "$disable_svg" != "t" ]; then
+		check_lib "librsvg-2.0"
+	fi
 }
 
 add () {
@@ -65,6 +69,9 @@ add_modules () {
 	add "prefix = $prefix"
 	test -z "$libdir" || add "libdir = $libdir"
 	test -z "$libexecdir" || add "libexecdir = $libexecdir"
+	if [ "$disable_svg" != "t" ]; then
+		add "RSVG=1"
+	fi
 	if [ "$enable_asan" = "t" ]; then
 		add "ASAN=1"
 	fi
@@ -113,6 +120,8 @@ main () {
 			with_pmenu=t ;;
 		--enable-asan)
 			enable_asan=t ;;
+		--disable-svg)
+			disable_svg=t ;;
 		-a|--all)
 			with_all ;;
 		-d|--dev)

--- a/src/icon.c
+++ b/src/icon.c
@@ -12,7 +12,9 @@
  *	  (using the "get_surface" functions).
  */
 
+#ifdef RSVG
 #include <librsvg/rsvg.h>
+#endif
 #include <png.h>
 
 #include "icon.h"
@@ -95,6 +97,7 @@ static cairo_surface_t *get_png_icon(const char *filename)
 	return image;
 }
 
+#ifdef RSVG
 static cairo_surface_t *get_svg_icon(const char *filename, int size)
 {
 	cairo_surface_t *surface;
@@ -131,6 +134,7 @@ static cairo_surface_t *get_svg_icon(const char *filename, int size)
 
 	return surface;
 }
+#endif
 
 void icon_set_name(const char *name)
 {
@@ -153,8 +157,10 @@ cairo_surface_t *load_cairo_icon(const char *path, int icon_size)
 {
 	if (strstr(path, ".png"))
 		return get_png_icon(path);
+#ifdef RSVG
 	else if (strstr(path, ".svg"))
 		return get_svg_icon(path, icon_size);
+#endif
 	else if (strstr(path, ".xpm"))
 		return get_xpm_icon(path);
 	return NULL;

--- a/src/x11-ui.h
+++ b/src/x11-ui.h
@@ -7,7 +7,9 @@
 #include <cairo.h>
 #include <cairo-xlib.h>
 #include <pango/pangocairo.h>
+#ifdef RSVG
 #include <librsvg/rsvg.h>
+#endif
 
 #include "align.h"
 


### PR DESCRIPTION
This moves librsvg dependency to optional with a configure `--disable-svg`.

Fixes #195.