### PR TITLE
debian control missing python3-gi for gtk module

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,8 @@ Build-Depends: debhelper (>= 10), libx11-dev, libxrandr-dev, libcairo2-dev,
 Package: jgmenu
 Architecture: any
 Multi-Arch: foreign
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3
-Suggests: lxmenu-data
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-gi
+Suggests: lxmenu-data, xranrd
 Description: Simple X11 menu
  A stand-alone, contemporary-looking menu application for Linux and BSD.
  Independent of window manager and panel. Designed for customisation,


### PR DESCRIPTION
it gives error in minimalistic setups due disabling recommends