### PR TITLE
lockfile respects xdg base directories

### DIFF
--- a/src/lockfile.c
+++ b/src/lockfile.c
@@ -8,7 +8,20 @@
 #include "sbuf.h"
 #include "banned.h"
 
-#define LOCKFILE "~/.jgmenu-lockfile"
+//#define LOCKFILE "~/.jgmenu-lockfile"
+#define LOCKFILE get_lockfile()
+
+const char* get_lockfile() {
+        const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
+        static char lockfile_path[PATH_MAX];
+        if (xdg_runtime_dir != NULL && xdg_runtime_dir[0] != '\0') {
+                snprintf(lockfile_path, sizeof(lockfile_path), "%s/jgmenu-lockfile", xdg_runtime_dir);
+                return lockfile_path;
+        } else {
+                return "~/.jgmenu-lockfile";
+        }
+}
+
 static struct sbuf lockfile;
 
 void lockfile_unlink(void)


### PR DESCRIPTION
Wrote a function that will check if there's `$XDG_RUNTIME_DIR` and use it if it exists. If not, it will use the initial home dotfile

It deals with this issue: https://github.com/jgmenu/jgmenu/issues/128