### PR TITLE
build: add -Wno-expansion-to-defined

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -19,7 +19,7 @@ CFLAGS  += -g -Wall -Os -std=gnu99
 CFLAGS  += -Wextra -Wdeclaration-after-statement -Wno-format-zero-length \
 	   -Wold-style-definition -Woverflow -Wpointer-arith \
 	   -Wstrict-prototypes -Wunused -Wvla -Wunused-result
-CFLAGS  += -Wno-unused-parameter
+CFLAGS  += -Wno-unused-parameter -Wno-expansion-to-defined
 CFLAGS  += -DVERSION='"$(VER)"'
 
 ifdef ASAN


### PR DESCRIPTION
...to avoid warning:

```
     CC    jgmenu.o
In file included from src/x11-ui.h:11,
                 from src/jgmenu.c:27:
/usr/lib/pkgconfig/../../include/librsvg-2.0/librsvg/rsvg.h:1331:1: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
 1331 | #if LIBRSVG_CHECK_FEATURE(PIXBUF)
      | ^~~~~~~~~~~~~~~~~~~
     CC    x11-ui.o
```