### PR TITLE
jgmenu: ignore entries with empty commands when de-duplicating

### DIFF
--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -337,14 +337,15 @@ static void add_if_unique(struct item *item)
 {
 	struct item *p;
 
-	if (!item->cmd)
-		return;
+	if (!item->cmd || !*item->cmd)
+		goto add;
 	list_for_each_entry(p, &menu.filter, filter) {
-		if (!p->cmd)
+		if (!p->cmd || !*p->cmd)
 			continue;
 		if (!strcmp(item->cmd, p->cmd))
 			return;
 	}
+add:
 	list_add_tail(&item->filter, &menu.filter);
 }
 


### PR DESCRIPTION
...search results.

For example with the csv data below - where the commas at the end force an empty command - we want a search for "aa" to render two results rather than one.

```
a,
aa,
aaa,
b,
bb,
bbb,
```

Fixes: #227