### PR TITLE
Support multi-line menu items with dynamic item height

### DIFF
--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -1178,8 +1178,7 @@ static void get_unique_tag_item(char *utag)
 }
 
 /**
- * Fonction perso pour adapter la hauteur des lignes au texte
- * en cas de description multiligne avec ('\n') dans le fichier csv
+ * Support multi-line menu items with dynamic item height.
  */
 static int item_text_height(struct item *item)
 {

--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -1178,13 +1178,26 @@ static void get_unique_tag_item(char *utag)
 }
 
 /**
- * Support multi-line menu items with dynamic item height.
+ * Support multi-line menu items with dynamic item height while preserving
+ * the vertical padding of single-line items.
  */
 static int item_text_height(struct item *item)
 {
+	static int font_height = -1;
 	struct point point;
+	int padding;
+
+	if (font_height == -1)
+		font_height = ui_get_text_size("abcfghjklABC",
+					       font_get()).y;
+
 	point = ui_get_text_size(item->name, font_get());
-	return point.y > config.item_height ? point.y : config.item_height;
+
+	padding = config.item_height - font_height;
+
+	return point.y + padding > config.item_height ?
+	       point.y + padding :
+	       config.item_height;
 }
 
 static void insert_tag_item(void)

--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -580,7 +580,7 @@ static void draw_icon(struct item *p, double alpha)
 	offsetx = cairo_image_surface_get_width(p->icon) < config.icon_size ?
 		  (config.icon_size - cairo_image_surface_get_width(p->icon)) / 2 : 0;
 
-	icon_y_coord = p->area.y + (config.item_height - config.icon_size) / 2 +
+	icon_y_coord = p->area.y + (p->area.h - config.icon_size) / 2 +
 		       offsety;
 	if (config.item_halign != RIGHT)
 		ui_insert_image(p->icon, p->area.x + config.item_padding_x +
@@ -1177,6 +1177,17 @@ static void get_unique_tag_item(char *utag)
 	snprintf(utag, UTAG_BUFSIZ, "%d,^tag(%d", i, i);
 }
 
+/**
+ * Fonction perso pour adapter la hauteur des lignes au texte
+ * en cas de description multiligne avec ('\n') dans le fichier csv
+ */
+static int item_text_height(struct item *item)
+{
+	struct point point;
+	point = ui_get_text_size(item->name, font_get());
+	return point.y > config.item_height ? point.y : config.item_height;
+}
+
 static void insert_tag_item(void)
 {
 	struct item *item = NULL;
@@ -1198,7 +1209,7 @@ static void insert_tag_item(void)
 	item->icon = NULL;
 	item->tag = item->cmd + 5;
 	item->selectable = 1;
-	item->area.h = config.item_height;
+	item->area.h = item_text_height(item);
 	list_add_tail(&item->master, &menu.master);
 }
 
@@ -1299,7 +1310,7 @@ static int read_csv_file(FILE *fp, bool ispipemenu)
 		else
 			item->tag = NULL;
 		item->selectable = 1;
-		item->area.h = config.item_height;
+		item->area.h = item_text_height(item);
 		if (!strncmp(item->name, "^sep(", 5)) {
 			item->selectable = 0;
 			if (item->name[5] == '\0')

--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -1231,11 +1231,11 @@ static void resolve_newline(char *s)
 
 	if (!s)
 		return;
-	p = strstr(s, "\\n");
-	if (!p)
-		return;
-	*p = ' ';
-	*(p + 1) = '\n';
+	while ((p = strstr(s, "\\n"))) {
+		*p = ' ';
+		*(p + 1) = '\n';
+		s = p + 2;
+	}
 }
 
 /**

--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -1181,7 +1181,7 @@ static void get_unique_tag_item(char *utag)
  * Support multi-line menu items with dynamic item height while preserving
  * the vertical padding of single-line items.
  */
-static int item_text_height(struct item *item)
+static int item_height(struct item *item)
 {
 	static int font_height = -1;
 	struct point point;
@@ -1221,7 +1221,7 @@ static void insert_tag_item(void)
 	item->icon = NULL;
 	item->tag = item->cmd + 5;
 	item->selectable = 1;
-	item->area.h = item_text_height(item);
+	item->area.h = item_height(item);
 	list_add_tail(&item->master, &menu.master);
 }
 
@@ -1322,7 +1322,7 @@ static int read_csv_file(FILE *fp, bool ispipemenu)
 		else
 			item->tag = NULL;
 		item->selectable = 1;
-		item->area.h = item_text_height(item);
+		item->area.h = item_height(item);
 		if (!strncmp(item->name, "^sep(", 5)) {
 			item->selectable = 0;
 			if (item->name[5] == '\0')


### PR DESCRIPTION
Hello!

I've been using jgmenu for almost two years now, and I think it's great. I hope this project isn't going to be abandoned! I think quite a few people still use X11, especially with Openbox...

I'd like to suggest a small change, if possible: this pull request adds support for menu items containing explicit line breaks by automatically adjusting the item height.

Currently, jgmenu supports `\n` in item names, and Pango correctly renders multi-line text. However, each menu item keeps the fixed `item_height` value, which means that the selection background and the clickable area do not cover the complete text when an item spans multiple lines.

This change calculates the required text height for each item using `ui_get_text_size()` and uses the larger value between the calculated height and the configured `item_height`.

Single-line items keep the current behaviour, while multi-line items automatically expand vertically.

The change also updates icon vertical alignment to use the actual item height instead of the configured default height, so icons remain centered in expanded items.

Thanks again for all your work on jgmenu!

P.S.: This is my very first pull request... I hope I didn't make any mistakes ;)