### PR TITLE
Add option to ignore _NET_WORKAREA in pointer mode

### DIFF
--- a/docs/manual/jgmenu.1.md
+++ b/docs/manual/jgmenu.1.md
@@ -479,6 +479,12 @@ Here follow some specific types:
     :   Launch at center of screen and ignore `_NET_WORKAREA`.
         Take precedence over `menu_{v,h}align`.
 
+`respect_workarea` = __integer__ (default 1)
+
+:   Whether to respect `_NET_WORKAREA` when positioning the menu.
+    Set to 0 to ignore reserved areas such as panels while keeping
+    pointer positioning.
+
 `edge_snap_x` = __integer__ (default 30)
 
 :   Specify the distance (in pixels) from the left hand edge, within which the

--- a/src/config.c
+++ b/src/config.c
@@ -175,6 +175,10 @@ void config_process_line(char *line)
 			warn("position_mode value '%s' not recognised", value);
 		}
 
+	} else if (!strcmp(option, "respect_workarea")) {
+		xatoi(&config.respect_workarea, value, XATOI_NONNEG,
+		      "config.respect_workarea");
+
 	} else if (!strcmp(option, "edge_snap_x")) {
 		xatoi(&config.edge_snap_x, value, XATOI_NONNEG,
 		      "config.edge_snap_x");


### PR DESCRIPTION
Hello again!

This pull request adds a new `respect_workarea` configuration option.

The code of `jgmenu` already contains support for enabling or disabling `_NET_WORKAREA` handling through the internal `config.respect_workarea` variable. However, this value was only controlled internally by `position_mode` and could not be overridden from the configuration file.

Currently, `position_mode = pointer` always enables `_NET_WORKAREA` handling. This can cause jgmenu to appear offset from the mouse pointer when a panel reserves space through `_NET_WORKAREA`.

For example, when using a panel such as polybar at the top of the screen, right-clicking the panel to open jgmenu may place the menu below the panel instead of at the current pointer position.

This change exposes the existing behaviour as a user-configurable option:

```
position_mode = pointer
respect_workarea = 0
```

With this configuration, jgmenu keeps pointer positioning while ignoring `_NET_WORKAREA` margins.

The default behaviour is unchanged: `respect_workarea` remains enabled unless explicitly disabled.

PS : this addresses issue #227, problem 3 ;)