### PR TITLE
Add configurable height for text separators (sep_text_height configuration option)

### DIFF
--- a/docs/manual/jgmenu.1.md
+++ b/docs/manual/jgmenu.1.md
@@ -659,8 +659,11 @@ Here follow some specific types:
 
 `sep_height` = __integer__ (default 5)
 
-:   Height of separator without text (defined by ^sep()). Separators with text
-    use `item_height`
+:   Height of separator without text (defined by ^sep()).
+
+`sep_text_height` = __integer__ (default 25)
+
+:   Height of separator with text (defined by ^sep(text)).
 
 `sep_halign` = (left | center | right) (default left)
 

--- a/src/config.c
+++ b/src/config.c
@@ -68,6 +68,7 @@ void config_set_defaults(void)
 	config.item_halign	   = LEFT;
 
 	config.sep_height	   = 5;
+	config.sep_text_height = 25;
 	config.sep_markup	   = NULL;
 	config.sep_halign	   = CENTER;
 
@@ -322,6 +323,9 @@ void config_process_line(char *line)
 	} else if (!strcmp(option, "sep_height")) {
 		xatoi(&config.sep_height, value, XATOI_NONNEG,
 		      "config.sep_height");
+	} else if (!strcmp(option, "sep_text_height")) {
+		xatoi(&config.sep_text_height, value, XATOI_GT_0,
+		      "config.sep_text_height");
 	} else if (!strcmp(option, "sep_markup")) {
 		xfree(config.sep_markup);
 		config.sep_markup = xstrdup(value);

--- a/src/config.h
+++ b/src/config.h
@@ -60,6 +60,7 @@ struct config {
 	int item_border;
 	enum alignment item_halign;
 	int sep_height;
+	int sep_text_height;
 	char *sep_markup;
 	enum alignment sep_halign;
 

--- a/src/jgmenu-config.c
+++ b/src/jgmenu-config.c
@@ -68,6 +68,7 @@ static struct option options[] = {
 	{ "item_border", "0" },
 	{ "item_halign", "left" },
 	{ "sep_height", "5" },
+	{ "sep_text_height", "25" },
 	{ "sep_halign", "left" },
 	{ "sep_markup", "" },
 	{ "font", "" },

--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -1304,6 +1304,8 @@ static int read_csv_file(FILE *fp, bool ispipemenu)
 			item->selectable = 0;
 			if (item->name[5] == '\0')
 				item->area.h = config.sep_height;
+			else
+				item->area.h = config.sep_text_height;
 		}
 		list_add_tail(&item->master, &menu.master);
 	}


### PR DESCRIPTION
This will be my last PR ;)

Addresses #227 (point 7).

This PR adds the sep_text_height configuration option requested there.
Text separators (^sep(text)) previously used item_height, making it impossible to adjust their height independently from regular menu items.

This PR, together with #260, would address all remaining points from #227 and allow the issue to be closed.