### PR TITLE
Fix Pango markup handling in @search widget

### DIFF
--- a/src/widgets.c
+++ b/src/widgets.c
@@ -106,11 +106,15 @@ static void draw_search(struct widget **w)
 	int padding_left = 4;
 
 	sbuf_init(&label_escaped);
-	sbuf_cpy(&label_escaped, filter_needle_length() ? filter_needle() :
-		 (*w)->content);
-	sbuf_replace(&label_escaped, "&", "&amp;");
-	sbuf_replace(&label_escaped, "<", "&lt;");
-	sbuf_replace(&label_escaped, ">", "&gt;");
+
+	if (filter_needle_length()) {
+		sbuf_cpy(&label_escaped, filter_needle());
+		sbuf_replace(&label_escaped, "&", "&amp;");
+		sbuf_replace(&label_escaped, "<", "&lt;");
+		sbuf_replace(&label_escaped, ">", "&gt;");
+	} else {
+		sbuf_cpy(&label_escaped, (*w)->content);
+	}
 
 	if (config.search_markup && config.search_markup[0] != '\0') {
 		sbuf_prepend(&label_escaped, ">");


### PR DESCRIPTION
Finally, since I have a little time on my hands right now, I figured I'd also take a look at a few bugs that interest me. That's why I'm submitting this new pull request.

This fixes the regression reported in issue #237.

The problem was introduced by commit `ff42f5a` ("widgets: escape special characters in search"), which fixed issue #194 by escaping `<`, `>` and `&` before rendering the search text with Pango markup.

That change correctly fixed the case where user-entered search text contains characters that are meaningful to Pango markup. However, it also escaped the static content of the `@search` widget, which can contain Pango markup just like other menu items.

For example:

```
@search,,7,5,450,24,0,left,top,auto,#000000 0,<i>Search...</i>
```

was transformed into:

```
&lt;i&gt;Search...&lt;/i&gt;
```

before being passed to `pango_layout_set_markup()`, so the markup was rendered as literal text instead of being interpreted.

This patch keeps escaping for user-entered search text, but leaves the static `@search` widget content untouched. This restores the expected Pango markup behaviour while preserving the fix introduced for issue #194.

I also verified that entering search terms containing `<`, `>` or `&` still works correctly and does not produce Pango parsing errors.