### PR TITLE
Add focus_on_open configuration option

### DIFF
--- a/docs/manual/jgmenu.1.md
+++ b/docs/manual/jgmenu.1.md
@@ -440,6 +440,10 @@ Here follow some specific types:
     jgmenu during the boot process and then sending a `killall -SIGUSR1 jgmenu`
     to show the menu.
 
+`focus_on_open` = __boolean__ (default 0)
+
+:   If set to 1, jgmenu will focus the first selectable item when opening.
+
 `csv_cmd` = __string__ (default `apps`)
 
 :   Defines the command to produce the jgmenu flavoured CSV for `jgmenu`.

--- a/src/config.c
+++ b/src/config.c
@@ -23,6 +23,7 @@ void config_set_defaults(void)
 	config.stay_alive	   = 1;
 	config.persistent          = 0;
 	config.hide_on_startup	   = 0;
+	config.focus_on_open	   = 0;
 	config.csv_cmd		   = xstrdup("apps");
 	config.tint2_look	   = 0;
 	config.position_mode	   = POSITION_MODE_FIXED;
@@ -143,6 +144,9 @@ void config_process_line(char *line)
 	} else if (!strcmp(option, "hide_on_startup")) {
 		xatoi(&config.hide_on_startup, value, XATOI_NONNEG,
 		      "config.hide_on_startup");
+	} else if (!strcmp(option, "focus_on_open")) {
+		xatoi(&config.focus_on_open, value, XATOI_NONNEG,
+		      "config.focus_on_open");
 	} else if (!strcmp(option, "csv_cmd")) {
 		xfree(config.csv_cmd);
 		config.csv_cmd = xstrdup(value);

--- a/src/config.h
+++ b/src/config.h
@@ -16,6 +16,7 @@ struct config {
 	int stay_alive;
 	int persistent;
 	int hide_on_startup;
+	int focus_on_open;
 	char *csv_cmd;
 	int tint2_look;
 	enum position_mode position_mode;

--- a/src/jgmenu-config.c
+++ b/src/jgmenu-config.c
@@ -28,6 +28,7 @@ static struct option options[] = {
 	{ "stay_alive", "1" },
 	{ "persistent", "0" },
 	{ "hide_on_startup", "0" },
+	{ "focus_on_open", "0" },
 	{ "csv_cmd", "apps" },
 	{ "tint2_look", "0" },
 	{ "position_mode", "fixed" },

--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -1035,8 +1035,12 @@ static void awake_menu(void)
 		update(1);
 	}
 
-	/* Remove previous selection on awake */
-	menu.sel = NULL;
+	if (config.focus_on_open) {
+		menu.sel = first_selectable();
+		menu.current_node->last_sel = menu.sel;
+	} else {
+		menu.sel = NULL;
+	}
 	draw_menu();
 
 	XMapWindow(ui->dpy, ui->w[ui->cur].win);
@@ -2770,7 +2774,12 @@ int main(int argc, char *argv[])
 	else
 		XMapRaised(ui->dpy, ui->w[ui->cur].win);
 
-	menu.sel = NULL;
+	if (config.focus_on_open) {
+		menu.sel = first_selectable();
+		menu.current_node->last_sel = menu.sel;
+	} else {
+		menu.sel = NULL;
+	}
 	draw_menu();
 
 	atexit(cleanup);


### PR DESCRIPTION
This adds a new `focus_on_open` configuration option.

This change follows commit dba87cf216e463b39002f033619e69aae1a51225 ("Do not focus any item on launch/awake"), which changed jgmenu so that no item is selected when the menu is opened.

The new option allows users who prefer the previous behaviour to restore automatic focus on the first selectable item when the main menu is opened.

The default value is `0`, so the current behaviour remains unchanged unless the user explicitly enables `focus_on_open`.

The implementation is intentionally limited to the menu opening path: when enabled, the initial menu selection is set to `first_selectable()` and `last_sel` is updated accordingly. This keeps keyboard navigation consistent after opening while leaving submenu selection behaviour unchanged.

The change only introduces a new configuration option and does not alter the existing selection logic.