### PR TITLE
Add respect_workarea to default config

### DIFF
--- a/src/jgmenu-config.c
+++ b/src/jgmenu-config.c
@@ -32,6 +32,7 @@ static struct option options[] = {
 	{ "csv_cmd", "apps" },
 	{ "tint2_look", "0" },
 	{ "position_mode", "fixed" },
+	{ "respect_workarea", "1" },
 	{ "edge_snap_x", "30" },
 	{ "terminal_exec", "x-terminal-emulator" },
 	{ "terminal_args", "-e" },


### PR DESCRIPTION
`respect_workarea` is handled by the configuration parser but was missing from the list of default options in `src/jgmenu-config.c`.

This ensures that `jgmenu_run init` includes `respect_workarea = 1` in the generated default configuration.

Fixes #265.