### PR TITLE
Add caret to search widget

### DIFF
--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -497,7 +497,7 @@ static void draw_item_sep_with_text(struct item *p)
 			  p->area.h, config.item_radius, 1.0, 0,
 			  config.color_title_border);
 	ui_insert_text(s.buf, text_x_coord, p->area.y, p->area.h, p->area.w,
-		       config.color_title_fg, config.sep_halign, 0);
+		       config.color_title_fg, config.sep_halign);
 	xfree(s.buf);
 }
 
@@ -547,11 +547,11 @@ static void draw_item_text(struct item *p)
 	if (p == menu.sel)
 		ui_insert_text(p->name, text_x_coord, p->area.y,
 			       p->area.h, width, config.color_sel_fg,
-			       config.item_halign, 0);
+			       config.item_halign);
 	else
 		ui_insert_text(p->name, text_x_coord, p->area.y,
 			       p->area.h, width, config.color_norm_fg,
-			       config.item_halign, 0);
+			       config.item_halign);
 }
 
 static void draw_submenu_arrow(struct item *p)
@@ -563,11 +563,11 @@ static void draw_submenu_arrow(struct item *p)
 		ui_insert_text(config.arrow_string, p->area.x + p->area.w -
 			       config.item_padding_x - (config.arrow_width * 0.7), p->area.y,
 			       p->area.h, p->area.w, color,
-			       config.item_halign, 0);
+			       config.item_halign);
 	else
 		ui_insert_text(config.arrow_string, p->area.x + config.item_padding_x,
 			       p->area.y, p->area.h, config.arrow_width * 0.7,
-			       color, config.item_halign, 0);
+			       color, config.item_halign);
 }
 
 static void draw_icon(struct item *p, double alpha)

--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -497,7 +497,7 @@ static void draw_item_sep_with_text(struct item *p)
 			  p->area.h, config.item_radius, 1.0, 0,
 			  config.color_title_border);
 	ui_insert_text(s.buf, text_x_coord, p->area.y, p->area.h, p->area.w,
-		       config.color_title_fg, config.sep_halign);
+		       config.color_title_fg, config.sep_halign, 0);
 	xfree(s.buf);
 }
 
@@ -547,11 +547,11 @@ static void draw_item_text(struct item *p)
 	if (p == menu.sel)
 		ui_insert_text(p->name, text_x_coord, p->area.y,
 			       p->area.h, width, config.color_sel_fg,
-			       config.item_halign);
+			       config.item_halign, 0);
 	else
 		ui_insert_text(p->name, text_x_coord, p->area.y,
 			       p->area.h, width, config.color_norm_fg,
-			       config.item_halign);
+			       config.item_halign, 0);
 }
 
 static void draw_submenu_arrow(struct item *p)
@@ -563,11 +563,11 @@ static void draw_submenu_arrow(struct item *p)
 		ui_insert_text(config.arrow_string, p->area.x + p->area.w -
 			       config.item_padding_x - (config.arrow_width * 0.7), p->area.y,
 			       p->area.h, p->area.w, color,
-			       config.item_halign);
+			       config.item_halign, 0);
 	else
 		ui_insert_text(config.arrow_string, p->area.x + config.item_padding_x,
 			       p->area.y, p->area.h, config.arrow_width * 0.7,
-			       color, config.item_halign);
+			       color, config.item_halign, 0);
 }
 
 static void draw_icon(struct item *p, double alpha)

--- a/src/widgets.c
+++ b/src/widgets.c
@@ -124,12 +124,14 @@ static void draw_search(struct widget **w)
 	}
 
 	if (filter_needle_length()) {
-		ui_insert_text(label_escaped.buf, (*w)->x + padding_left,
-			       (*w)->y, (*w)->h, (*w)->w, (*w)->fgcol, LEFT, 1);
+		ui_insert_text_with_caret(label_escaped.buf, (*w)->x + padding_left,
+			(*w)->y, (*w)->h, (*w)->w, (*w)->fgcol, LEFT,
+			CARET_AT_END);
 	} else {
 		sbuf_prepend(&label_escaped, " ");
-		ui_insert_text(label_escaped.buf, (*w)->x + padding_left,
-			       (*w)->y, (*w)->h, (*w)->w, (*w)->fgcol, LEFT, -1);
+		ui_insert_text_with_caret(label_escaped.buf, (*w)->x + padding_left,
+				(*w)->y, (*w)->h, (*w)->w, (*w)->fgcol, LEFT,
+				CARET_AT_START);
 	}
 	free(label_escaped.buf);
 }
@@ -137,7 +139,7 @@ static void draw_search(struct widget **w)
 static void draw_text(struct widget **w)
 {
 	ui_insert_text((*w)->content, (*w)->x, (*w)->y, (*w)->h, (*w)->w,
-		       (*w)->fgcol, LEFT, 0);
+		       (*w)->fgcol, LEFT);
 }
 
 static void draw_selection(struct widget **w)

--- a/src/widgets.c
+++ b/src/widgets.c
@@ -123,15 +123,21 @@ static void draw_search(struct widget **w)
 		sbuf_addstr(&label_escaped, "</span>");
 	}
 
-	ui_insert_text(label_escaped.buf, (*w)->x + padding_left, (*w)->y,
-		       (*w)->h, (*w)->w, (*w)->fgcol, LEFT);
+	if (filter_needle_length()) {
+		ui_insert_text(label_escaped.buf, (*w)->x + padding_left,
+			       (*w)->y, (*w)->h, (*w)->w, (*w)->fgcol, LEFT, 1);
+	} else {
+		sbuf_prepend(&label_escaped, " ");
+		ui_insert_text(label_escaped.buf, (*w)->x + padding_left,
+			       (*w)->y, (*w)->h, (*w)->w, (*w)->fgcol, LEFT, -1);
+	}
 	free(label_escaped.buf);
 }
 
 static void draw_text(struct widget **w)
 {
 	ui_insert_text((*w)->content, (*w)->x, (*w)->y, (*w)->h, (*w)->w,
-		       (*w)->fgcol, LEFT);
+		       (*w)->fgcol, LEFT, 0);
 }
 
 static void draw_selection(struct widget **w)

--- a/src/x11-ui.c
+++ b/src/x11-ui.c
@@ -533,7 +533,7 @@ void ui_draw_line(double x0, double y0, double x1, double y1, double line_width,
 }
 
 void ui_insert_text(char *s, int x, int y, int h, int w, double *rgba,
-		    enum alignment align, int caret)
+		    enum alignment align)
 {
 	PangoTabArray *tabs;
 	int height;
@@ -561,19 +561,34 @@ void ui_insert_text(char *s, int x, int y, int h, int w, double *rgba,
 	/* use (h - height) / 2 to center-align vertically */
 	cairo_move_to(ui->w[ui->cur].c, x, y + (h - height) / 2);
 	pango_cairo_show_layout(ui->w[ui->cur].c, ui->w[ui->cur].pangolayout);
-
-	if (caret) {
-		int width;
-
-		pango_layout_get_pixel_size(ui->w[ui->cur].pangolayout, &width, NULL);
-		if (caret < 0)
-			width = -2.5;
-		ui_draw_line(x + width + 2.5, y + (h - height) / 2,
-			     x + width + 2.5, y + (h + height) / 2,
-			     1.0, rgba);
-	}
-
 	pango_tab_array_free(tabs);
+}
+
+void ui_insert_text_with_caret(char *s, int x, int y, int h, int w,
+			       double *rgba, enum alignment align,
+			       enum caret_position position)
+{
+	int width;
+	int height;
+	double caret_x;
+
+	ui_insert_text(s, x, y, h, w, rgba, align);
+
+	pango_layout_get_pixel_size(ui->w[ui->cur].pangolayout, &width, &height);
+
+	/*
+	 * Use a 2.5-pixel offset to keep the 1-pixel caret sharp.
+	 * Integer offsets (e.g. 2 or 3) cause Cairo to anti-alias the
+	 * line, making the caret appear wider and darker than intended.
+	 */
+	if (position == CARET_AT_START)
+		caret_x = x + 2.5;
+	else
+		caret_x = x + width + 2.5;
+
+	ui_draw_line(caret_x, y + (h - height) / 2,
+		     caret_x, y + (h + height) / 2,
+		     1.0, rgba);
 }
 
 struct point ui_get_text_size(const char *str, const char *fontdesc)

--- a/src/x11-ui.c
+++ b/src/x11-ui.c
@@ -533,7 +533,7 @@ void ui_draw_line(double x0, double y0, double x1, double y1, double line_width,
 }
 
 void ui_insert_text(char *s, int x, int y, int h, int w, double *rgba,
-		    enum alignment align)
+		    enum alignment align, int caret)
 {
 	PangoTabArray *tabs;
 	int height;
@@ -561,6 +561,18 @@ void ui_insert_text(char *s, int x, int y, int h, int w, double *rgba,
 	/* use (h - height) / 2 to center-align vertically */
 	cairo_move_to(ui->w[ui->cur].c, x, y + (h - height) / 2);
 	pango_cairo_show_layout(ui->w[ui->cur].c, ui->w[ui->cur].pangolayout);
+
+	if (caret) {
+		int width;
+
+		pango_layout_get_pixel_size(ui->w[ui->cur].pangolayout, &width, NULL);
+		if (caret < 0)
+			width = -2.5;
+		ui_draw_line(x + width + 2.5, y + (h - height) / 2,
+			     x + width + 2.5, y + (h + height) / 2,
+			     1.0, rgba);
+	}
+
 	pango_tab_array_free(tabs);
 }
 

--- a/src/x11-ui.h
+++ b/src/x11-ui.h
@@ -66,8 +66,15 @@ void ui_draw_rectangle(double x, double y, double w, double h, double radius, do
 void ui_draw_rectangle_gradient(double x, double y, double w, double h, double radius, double line_width,
 				int fill, double *top_rgba, double *bot_rgba, enum alignment align);
 void ui_draw_line(double x0, double y0, double x1, double y1, double line_width, double *rgba);
+enum caret_position {
+	CARET_AT_START,
+	CARET_AT_END
+};
 void ui_insert_text(char *s, int x, int y, int h, int w, double *rgba,
-		    enum alignment align, int caret);
+		    enum alignment align);
+void ui_insert_text_with_caret(char *s, int x, int y, int h, int w,
+			double *rgba, enum alignment align,
+			enum caret_position position);
 struct point ui_get_text_size(const char *str, const char *fontdesc);
 int ui_is_point_in_area(struct point p, struct area a);
 void ui_map_window(unsigned int w, unsigned int h);

--- a/src/x11-ui.h
+++ b/src/x11-ui.h
@@ -67,7 +67,7 @@ void ui_draw_rectangle_gradient(double x, double y, double w, double h, double r
 				int fill, double *top_rgba, double *bot_rgba, enum alignment align);
 void ui_draw_line(double x0, double y0, double x1, double y1, double line_width, double *rgba);
 void ui_insert_text(char *s, int x, int y, int h, int w, double *rgba,
-		    enum alignment align);
+		    enum alignment align, int caret);
 struct point ui_get_text_size(const char *str, const char *fontdesc);
 int ui_is_point_in_area(struct point p, struct area a);
 void ui_map_window(unsigned int w, unsigned int h);


### PR DESCRIPTION
Hello!

I wanted to suggest a (more or less) minimalist PR to add a caret to the search widget and make the text input position visible.

## Changes

- Add optional caret support to `ui_insert_text()`.
- Display the caret at the end of the search text when the search field contains text.
- Display the caret before the `Search...` placeholder when the search field is empty.
- Use the widget's foreground color and a 1-pixel line width for the caret.
- Update existing `ui_insert_text()` callers to explicitly disable the caret.

I had to use a +2.5 pixel offset for the caret position. With +2, Cairo's anti-aliasing causes the 1-pixel stroke to be spread across two pixels, making the caret appear 2 pixels wide. Using +2.5 produces a sharp 1-pixel caret.

For an empty search field, I had to handle the caret slightly differently because the placeholder text is not actually part of the search input. I prepend a space to the placeholder and use a negative caret value so that the same caret-drawing code can place the caret immediately before `Search...`, without changing the placeholder's visual position.

The negative value is only used to distinguish this case from the normal caret-at-the-end-of-the-text case.