### PR TITLE
Fix NetBSD build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ VER      = $(shell ./scripts/version-gen.sh)
 -include config.mk
 include Makefile.inc
 
-jgmenu:         CFLAGS += `pkg-config cairo pango pangocairo $(RSVG_LIB) --cflags` $(RSVG_FLAGS)
+jgmenu:         CFLAGS += `pkg-config libpng cairo pango pangocairo $(RSVG_LIB) --cflags` $(RSVG_FLAGS)
+jgmenu:         CFLAGS += -pthread
 jgmenu-ob:      CFLAGS += `pkg-config --cflags libxml-2.0`
 jgmenu-obtheme: CFLAGS += `pkg-config --cflags libxml-2.0`
 jgmenu-config:  CFLAGS += `pkg-config --cflags glib-2.0`
 jgmenu-apps:    CFLAGS += `pkg-config --cflags glib-2.0`
 
-jgmenu:         LIBS   += `pkg-config x11 xrandr cairo pango pangocairo $(RSVG_LIB) --libs` $(RSVG_FLAGS)
-jgmenu:         LIBS   += -pthread -lpng
+jgmenu:         LIBS   += `pkg-config x11 xrandr libpng cairo pango pangocairo $(RSVG_LIB) --libs` $(RSVG_FLAGS)
 jgmenu-ob:      LIBS   += `pkg-config --libs libxml-2.0`
 jgmenu-obtheme: LIBS   += `pkg-config --libs libxml-2.0`
 jgmenu-config:  LIBS   += `pkg-config --libs glib-2.0`

--- a/src/argv-buf.c
+++ b/src/argv-buf.c
@@ -75,7 +75,7 @@ static void trim_all_fields(struct argv_buf *buf)
 	for (i = 0; i < buf->argc; i++) {
 		p = buf->argv[i];
 		rtrim(p);
-		while (isspace(*p))
+		while (isspace((unsigned char)*p))
 			p++;
 		buf->argv[i] = p;
 	}

--- a/src/filter.c
+++ b/src/filter.c
@@ -86,7 +86,7 @@ void filter_delword(void)
 
 	do {
 		filter_backspace();
-	} while (!isspace(needle.buf[needle.len - 1]) && needle.len);
+	} while (!isspace((unsigned char)needle.buf[needle.len - 1]) && needle.len);
 }
 
 void filter_reset(void)

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -115,7 +115,7 @@ void sbuf_ltrim(struct sbuf *s)
 	if (!s || !s->buf || !s->len)
 		return;
 	p = s->buf;
-	while (i < s->len && isspace(*p++))
+	while (i < s->len && isspace((unsigned char)*p++))
 		i++;
 	sbuf_shift_left(s, i);
 }
@@ -129,7 +129,7 @@ void sbuf_rtrim(struct sbuf *s)
 		return;
 	p = s->buf + s->len - 1;
 	while (i < s->len) {
-		if (!isspace(*p))
+		if (!isspace((unsigned char)*p))
 			break;
 		i++;
 		p--;

--- a/src/util.c
+++ b/src/util.c
@@ -106,7 +106,7 @@ void rtrim(char *s)
 	if (!len)
 		return;
 	end = s + len - 1;
-	while (end >= s && isspace(*end))
+	while (end >= s && isspace((unsigned char)*end))
 		end--;
 	*(end + 1) = '\0';
 }
@@ -114,7 +114,7 @@ void rtrim(char *s)
 char *strstrip(char *s)
 {
 	rtrim(s);
-	while (isspace(*s))
+	while (isspace((unsigned char)*s))
 		s++;
 	return s;
 }


### PR DESCRIPTION
...including:

    - Include -pthread in CFLAGS so that macros like -D_REENTRANT and -D_PTHREADS get defined when compiling source.
    - Use pkg-config rather than just adding -lpng to correctly link with libpng
    - Pass unsigned chars only to the isspace() as required by ANSI C

Related-to: #269